### PR TITLE
Update Makefile for macOS Clang + OpenMP + C++11

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,23 +1,43 @@
+CC = gcc
+CXX = g++
+
 DIR_INC = -I./
 DIR_INC += -I./layers
 DIR_INC += -I./dataloader
 DIR_INC += -I./checkpoint
 DIR_INC += -I./test
+
 DIR_LIB = -L./
-TARGET	= transformer
-CFLAGS = -g -Wall $(DIR_INC) $(DIR_LIB) -fsanitize=address -fopenmp -fno-omit-frame-pointer
-LDFLAGS += -lstdc++ -fopenmp
-SRCDIR+= ./matrix
-SRCDIR+= ./autograd
-SRCDIR+= ./stats
-SRCDIR+= ./layers
-SRCDIR+= ./dataloader
-SRCDIR+= ./checkpoint
-SRCDIR+= ./test
+
+TARGET = transformer
+
+# macOS system SDK and libomp paths
+SDK_PATH := $(shell xcrun --sdk macosx --show-sdk-path)
+OMP_INC = -I/opt/homebrew/opt/libomp/include
+OMP_LIB = -L/opt/homebrew/opt/libomp/lib
+
+# Clean CFLAGS: no linker flags here
+CFLAGS = -std=c++11 -g -Wall $(DIR_INC) \
+  -fsanitize=address \
+  -Xpreprocessor -fopenmp $(OMP_INC) \
+  -fno-omit-frame-pointer \
+  -isysroot $(SDK_PATH)
+
+# Clean LDFLAGS: includes libomp + project-specific lib path
+LDFLAGS = $(OMP_LIB) $(DIR_LIB) -lomp
+
+SRCDIR += ./matrix
+SRCDIR += ./autograd
+SRCDIR += ./stats
+SRCDIR += ./layers
+SRCDIR += ./dataloader
+SRCDIR += ./checkpoint
+SRCDIR += ./test
 
 SRCS := $(wildcard *.cpp) $(wildcard $(addsuffix /*.cpp, $(SRCDIR)))
-OBJECTS := $(patsubst %.c,%.o,$(SRCS))
-RELEASE_MSG="[warning!!!!!] Compiling with debug flags"
+OBJECTS := $(SRCS:.cpp=.o)
+
+RELEASE_MSG = "[warning!!!!!] Compiling with debug flags"
 ifeq ($(RELEASE),1)
 	CFLAGS += -O3
 	CFLAGS := $(filter-out -fsanitize=address, $(CFLAGS))
@@ -26,11 +46,14 @@ else
 	CFLAGS += -fsanitize=address
 endif
 
-$(TARGET) : $(OBJECTS)
+$(TARGET): $(OBJECTS)
 	@echo $(RELEASE_MSG)
-	g++ $(CFLAGS) $^ -o $@ $(LDFLAGS)
-%.o : %.c
-	g++ -c $(CFLAGS) $< -o $@
+	$(CXX) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+%.o: %.cpp
+	$(CXX) -c $(CFLAGS) $< -o $@
+
 clean:
-	@rm -f *.o $(TARGET)
-.PHONY:clean
+	@rm -f $(OBJECTS) $(TARGET)
+
+.PHONY: clean


### PR DESCRIPTION
With some help from ChatGPT 4o I was able to build your cpp-transformer project on a MacBook M3.
This pull request modifies the makefile so that the project can successfully compile and run on macOS using Apple Clang.
My Linux system is down so I have not been able to check whether the modified makefile still works there.

Changes:
	•	Enable OpenMP support via Homebrew’s libomp
	•	Detect system SDK path using xcrun for compatibility with Clang
	•	Add -std=c++11 to support C++ features like override and auto
	•	Clean up compiler vs linker flags to avoid Clang warnings

Tested and confirmed working on:
	•	MacBook Pro (M3 Max), macOS 14.4.1
	•	Apple Clang + libomp

The training and inference output on the Mac matches the output shown in your Readme.
Thank you for making this project available.

Ralph Dratman
(https://github.com/dratman/cpp-transformer-rd)